### PR TITLE
Add back the InitializePublicClientAppAsync() to iOS platform

### DIFF
--- a/MauiAppB2C/Platforms/iOS/AppDelegate.cs
+++ b/MauiAppB2C/Platforms/iOS/AppDelegate.cs
@@ -1,13 +1,21 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 using Foundation;
-using MauiB2C.MSALClient;
+using MAUIB2C.MSALClient;
+using Microsoft.Identity.Client;
 using UIKit;
-
 namespace MauiB2C;
 
 [Register("AppDelegate")]
 public class AppDelegate : MauiUIApplicationDelegate
 {
-	protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+
+    public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
+    {
+        // Initialize MSAL and platformConfig is set
+        IAccount existinguser = Task.Run(async () => await PublicClientSingleton.Instance.MSALClientHelper.InitializePublicClientAppAsync()).Result;
+
+        return base.FinishedLaunching(application, launchOptions);
+    }
 }

--- a/MauiAppB2C/Platforms/iOS/AppDelegate.cs
+++ b/MauiAppB2C/Platforms/iOS/AppDelegate.cs
@@ -2,22 +2,12 @@
 // Licensed under the MIT License.
 using Foundation;
 using MauiB2C.MSALClient;
-using Microsoft.Identity.Client;
 using UIKit;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace MauiB2C;
 
 [Register("AppDelegate")]
 public class AppDelegate : MauiUIApplicationDelegate
 {
-    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
-
-    public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
-    {
-        // Initialize MSAL and platformConfig is set
-        IAccount existinguser = Task.Run(async () => await PublicClientSingleton.Instance.MSALClientHelper.InitializePublicClientAppAsync()).Result;
-
-        return base.FinishedLaunching(application, launchOptions);
-    }
+	protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
 }

--- a/MauiAppB2C/Platforms/iOS/AppDelegate.cs
+++ b/MauiAppB2C/Platforms/iOS/AppDelegate.cs
@@ -2,12 +2,22 @@
 // Licensed under the MIT License.
 using Foundation;
 using MauiB2C.MSALClient;
+using Microsoft.Identity.Client;
 using UIKit;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace MauiB2C;
 
 [Register("AppDelegate")]
 public class AppDelegate : MauiUIApplicationDelegate
 {
-	protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+
+    public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
+    {
+        // Initialize MSAL and platformConfig is set
+        IAccount existinguser = Task.Run(async () => await PublicClientSingleton.Instance.MSALClientHelper.InitializePublicClientAppAsync()).Result;
+
+        return base.FinishedLaunching(application, launchOptions);
+    }
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* The iOS platform have not included the code to run InitializePublicClientAppAsync(), hence the iOS build crashed at runtime

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
Follow the test steps from the main branch.
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->