### PR TITLE
Add .NET MAUI to products metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ languages:
 - powershell
 products:
 - azure-active-directory
+- dotnet-maui
 description: "You have a MAUI application and you want it to consume Microsoft Graph or your own Web Api using Microsoft Identity Platform to acquire tokens."
 urlFragment: ms-identity-dotnetcore-maui
 ---


### PR DESCRIPTION
## Purpose

I've added `dotnet-maui` to the product metadata. That way the sample will also show up when users select the .NET MAUI filter in the samples browser.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```
